### PR TITLE
Add GitHub Issues Settings to Maintain Contribution Consistency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "githubIssues.issueBranchTitle": "${user}/issue/${issueNumber}-${sanitizedIssueTitle}",
+    "githubIssues.queries": [
+        {
+            "label": "My Issues",
+            "query": "default"
+        },
+        {
+            "label": "Created Issues",
+            "query": "author:${user} state:open repo:${owner}/${repository} sort:created-desc"
+        },
+        {
+            "label": "Open Issues",
+            "query": "state:open repo:${owner}/${repository} sort:created-desc"
+        }
+    ],
+}


### PR DESCRIPTION
Updated vscode/settings.json with standard naming conventions for GitHub issues.

Fixes #19