### PR TITLE
Pair Down Deployment Slots to Single Slot (Staging)

### DIFF
--- a/deployments/azure_app_service_helloworld_primary_region/azure_app_service_helloworld_primary_region.json
+++ b/deployments/azure_app_service_helloworld_primary_region/azure_app_service_helloworld_primary_region.json
@@ -41,7 +41,6 @@
         },
         "environments": {
             "defaultValue": [
-                "preview",
                 "staging"
             ],
             "type": "array",

--- a/deployments/azure_app_service_helloworld_primary_region/azure_app_service_helloworld_primary_region.md
+++ b/deployments/azure_app_service_helloworld_primary_region/azure_app_service_helloworld_primary_region.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-The Azure App Service Hello World Primary Region deployment creates a simple App Service with four additional deployment slots to the existing App Service Plan in the primary region.  This App Service acts as an Azure Traffic Manager Endpoint. Diagnostic settings are enabled for all resources utilizing Azure Log Analytics for log and metric storage.  Application Insights is configured for application monitoring.
+The Azure App Service Hello World Primary Region deployment creates a simple App Service with an additional deployment slot to the existing App Service Plan in the primary region.  This App Service acts as an Azure Traffic Manager Endpoint. Diagnostic settings are enabled for all resources utilizing Azure Log Analytics for log and metric storage.  Application Insights is configured for application monitoring.
 
 ## Files Required
 

--- a/deployments/azure_app_service_helloworld_secondary_region/azure_app_service_helloworld_secondary_region.json
+++ b/deployments/azure_app_service_helloworld_secondary_region/azure_app_service_helloworld_secondary_region.json
@@ -41,7 +41,6 @@
         },
         "environments": {
             "defaultValue": [
-                "preview",
                 "staging"
             ],
             "type": "array",

--- a/deployments/azure_app_service_helloworld_secondary_region/azure_app_service_helloworld_secondary_region.md
+++ b/deployments/azure_app_service_helloworld_secondary_region/azure_app_service_helloworld_secondary_region.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-The Azure App Service Hello World secondary Region deployment creates a simple App Service with four additional deployment slots to the existing App Service Plan in the secondary region.  This App Service acts as an Azure Traffic Manager Endpoint. Diagnostic settings are enabled for all resources utilizing Azure Log Analytics for log and metric storage.  Application Insights is configured for application monitoring.
+The Azure App Service Hello World secondary Region deployment creates a simple App Service with an additional deployment slot to the existing App Service Plan in the secondary region.  This App Service acts as an Azure Traffic Manager Endpoint. Diagnostic settings are enabled for all resources utilizing Azure Log Analytics for log and metric storage.  Application Insights is configured for application monitoring.
 
 ## Files Required
 

--- a/deployments/azure_app_service_imageresizer/azure_app_service_imageresizer.json
+++ b/deployments/azure_app_service_imageresizer/azure_app_service_imageresizer.json
@@ -53,7 +53,6 @@
         },
         "environments": {
             "defaultValue": [
-                "preview",
                 "staging"
             ],
             "type": "array",

--- a/deployments/azure_sql_todo/azure_sql_todo.json
+++ b/deployments/azure_sql_todo/azure_sql_todo.json
@@ -65,7 +65,6 @@
         },
         "environments": {
             "defaultValue": [
-                "preview",
                 "staging"
             ],
             "type": "array",


### PR DESCRIPTION
Fixes #13

Paired down App Service Deployment Slots to a single slot (Staging) for the following deployments:

- azure_app_service_helloworld_primary_region
- azure_app_service_helloworld_secondary_region
- azure_app_service_imageresizer
- azure_app_service_sql_todo

No Parameter or PowerShell Script adjustments required.