### PR TITLE
Added Alias Minimum and Maximum Length Validation

### DIFF
--- a/ade.ps1
+++ b/ade.ps1
@@ -11,6 +11,7 @@ param (
     # Shared Command Set Parameters
     ###################################################################################################
     [Parameter(Position = 1, mandatory = $true)]
+    [ValidateLength(1, 8)]
     [string]$alias,
 
     [Parameter(Position = 4, mandatory = $true, ParameterSetName = 'deploy-interactive')]


### PR DESCRIPTION
Added a `ValidateLength` attribute to the `alias` parameter to avoid long storage account names. Fixes #46