### PR TITLE
Reset Resource Group Before Execution

### DIFF
--- a/ade.ps1
+++ b/ade.ps1
@@ -120,7 +120,7 @@ try {
 
     # Setting the default location for services
     Write-Status "Setting the Default Resource Location to $defaultPrimaryRegion"
-    az configure --defaults location=$defaultPrimaryRegion
+    az configure --defaults location=$defaultPrimaryRegion group=
     Confirm-LastExitCode
 
     ###################################################################################################

--- a/modules/ADE/private/Policy/Remove-AzurePolicyAssignmentsAndDefinitions.ps1
+++ b/modules/ADE/private/Policy/Remove-AzurePolicyAssignmentsAndDefinitions.ps1
@@ -11,17 +11,21 @@ function Remove-AzurePolicyAssignmentsAndDefinitions {
     $azureMonitorforVMSSInitiativeAssignment = 'Enable Azure Monitor for Virtual Machine Scale Sets'
     $adeInitiativeDefinition = 'Azure Demo Environment Initiative'
 
-    az policy assignment delete -n $adeInitiativeAssignment
+    Write-Log "Removing Policy Assignment: $adeInitiativeAssignment"
+    az policy assignment delete -n "$adeInitiativeAssignment"
     Confirm-LastExitCode
     
+    Write-Log "Removing Policy Assignment: $azureMonitorforVMsInitiativeAssignment"
     az policy assignment delete -n $azureMonitorforVMsInitiativeAssignment
     Confirm-LastExitCode
     
+    Write-Log "Removing Policy Assignment: $azureMonitorforVMSSInitiativeAssignment"
     az policy assignment delete -n $azureMonitorforVMSSInitiativeAssignment
     Confirm-LastExitCode
     
+    Write-Log "Removing Policy Definition: $adeInitiativeDefinition"
     az policy set-definition delete -n $adeInitiativeDefinition
     Confirm-LastExitCode
 
-    Write-ScriptSection "Removing Azure Policy Assignments and Definitions"
+    Write-ScriptSection "Removed Azure Policy Assignments and Definitions"
 }


### PR DESCRIPTION
Remove the default resource group from `az` to fix Policy attempting to use the default (instead of using the subscription). Fixes #37