### PR TITLE
Add an Event Hub and Storage Account as part of the Activity Log and Diagnostics Settings

### DIFF
--- a/deployments/azure_app_services/azure_app_services_adeapp.bicep
+++ b/deployments/azure_app_services/azure_app_services_adeapp.bicep
@@ -21,6 +21,12 @@ param containerRegistryPassword string
 @description('The URL of the Azure Container Registry.')
 param containerRegistryURL string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -113,72 +119,42 @@ resource adeAppServiceDiagnostics 'Microsoft.insights/diagnosticSettings@2021-05
   name: '${adeAppAppService.adeAppAppServiceName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logs: [
       {
         category: 'AppServiceHTTPLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceConsoleLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAppLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceFileAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceIPSecAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServicePlatformLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_app_services/azure_app_services_inspectorgadget.bicep
+++ b/deployments/azure_app_services/azure_app_services_inspectorgadget.bicep
@@ -10,6 +10,12 @@ param adminUserName string
 @description('The ID of the App Service Plan.')
 param appServicePlanId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The name of the Inspector Gadget App Service.')
 param inspectorGadgetAppServiceName string
 
@@ -85,72 +91,42 @@ resource inspectorGadgetAppServiceDiagnostics 'Microsoft.insights/diagnosticSett
   name: '${inspectorGadgetAppService.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logs: [
       {
         category: 'AppServiceHTTPLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceConsoleLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAppLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceFileAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceIPSecAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServicePlatformLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_container_instances/azure_container_instances.bicep
+++ b/deployments/azure_container_instances/azure_container_instances.bicep
@@ -18,7 +18,6 @@ param rootDomainName string
 // Resource Groups
 var adeAppLoadTestingResourceGroupName = 'rg-ade-${aliasRegion}-adeapploadtesting'
 var containerRegistryResourceGroupName = 'rg-ade-${aliasRegion}-containerregistry'
-var monitorResourceGroupName = 'rg-ade-${aliasRegion}-monitor'
 // Resources
 var adeAppApiGatewayHostName = 'ade-apigateway.${rootDomainName}'
 var adeAppFrontEndHostName = 'ade-frontend.${rootDomainName}'
@@ -31,20 +30,12 @@ var adeLoadTestingInfluxDbContainerImageName = '${containerRegistry.properties.l
 var adeLoadTestingRedisContainerGroupName = 'ci-ade-${aliasRegion}-adeloadtesting-redis'
 var adeLoadTestingRedisContainerImageName = '${containerRegistry.properties.loginServer}/ade-loadtesting-redis:latest'
 var containerRegistryName = replace('acr-ade-${aliasRegion}-001', '-', '')
-var logAnalyticsWorkspaceName = 'log-ade-${aliasRegion}-001'
 
 // Existing Resource - Container Registry
 //////////////////////////////////////////////////
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' existing = {
   scope: resourceGroup(containerRegistryResourceGroupName)
   name: containerRegistryName
-}
-
-// Existing Resource - Log Analytics Workspace
-//////////////////////////////////////////////////
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
-  scope: resourceGroup(monitorResourceGroupName)
-  name: logAnalyticsWorkspaceName
 }
 
 // Resource Group - App Service Plan

--- a/deployments/azure_container_registry/azure_container_registry.bicep
+++ b/deployments/azure_container_registry/azure_container_registry.bicep
@@ -20,6 +20,8 @@ var monitorResourceGroupName = 'rg-ade-${aliasRegion}-monitor'
 // Resources
 var containerRegistryManagedIdentityName = 'id-ade-${aliasRegion}-containerregistry'
 var containerRegistryName = replace('acr-ade-${aliasRegion}-001', '-', '')
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var keyVaultName = 'kv-ade-${aliasRegion}-001'
 var logAnalyticsWorkspaceName = 'log-ade-${aliasRegion}-001'
 
@@ -44,6 +46,20 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
   name: logAnalyticsWorkspaceName
 }
 
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
+}
+
 // Resource Group - Container Registry
 //////////////////////////////////////////////////
 resource containerRegistryResourceGroup 'Microsoft.Resources/resourceGroups@2021-01-01' = {
@@ -61,6 +77,8 @@ module containerRegistryModule './azure_container_registry_adeapp.bicep' = {
   ]
   params: {
     containerRegistryName: containerRegistryName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     // containerRegistryManagedIdentityPrincipalID: containerRegistryManagedIdentity.properties
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }

--- a/deployments/azure_container_registry/azure_container_registry_adeapp.bicep
+++ b/deployments/azure_container_registry/azure_container_registry_adeapp.bicep
@@ -49,8 +49,6 @@ resource containerRegistryDiagnostics 'microsoft.insights/diagnosticSettings@202
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_container_registry/azure_container_registry_adeapp.bicep
+++ b/deployments/azure_container_registry/azure_container_registry_adeapp.bicep
@@ -3,6 +3,12 @@
 @description('The name of the Container Registry.')
 param containerRegistryName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 // @description('The Principal ID of the Container Registry Managed Identity.')
 // @secure()
 // param containerRegistryManagedIdentityPrincipalID string
@@ -41,33 +47,25 @@ resource containerRegistryDiagnostics 'microsoft.insights/diagnosticSettings@202
   scope: containerRegistry
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'ContainerRegistryRepositoryEvents'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'ContainerRegistryLoginEvents'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_databases/azure_databases.bicep
+++ b/deployments/azure_databases/azure_databases.bicep
@@ -28,6 +28,8 @@ var adeAppSqlServerName = 'sql-ade-${aliasRegion}-adeapp'
 var adeAppSqlServerPrivateEndpointName = 'pl-ade-${aliasRegion}-adeappsql'
 var appConfigName = 'appcs-ade-${aliasRegion}-001'
 var azureSqlPrivateDnsZoneName = 'privatelink${environment().suffixes.sqlServerHostname}'
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var inspectorGadgetSqlDatabaseName = 'sqldb-ade-${aliasRegion}-inspectorgadget'
 var inspectorGadgetSqlServerName = 'sql-ade-${aliasRegion}-inspectorgadget'
 var inspectorGadgetSqlServerPrivateEndpointName = 'pl-ade-${aliasRegion}-inspectorgadgetsql'
@@ -55,6 +57,20 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
   scope: resourceGroup(monitorResourceGroupName)
   name: logAnalyticsWorkspaceName
+}
+
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
 }
 
 // Existing Resource - Private Dns Zone - Azure Sql
@@ -104,6 +120,8 @@ module adeAppSqlModule './azure_databases_adeapp_sql.bicep' = {
     appConfigName: appConfig.name
     appConfigResourceGroupName: appConfigResourceGroupName
     azureSqlPrivateDnsZoneId: azureSqlPrivateDnsZone.id
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     privateEndpointSubnetId: virtualNetwork002::privateEndpointSubnet.id
   }
@@ -124,6 +142,8 @@ module inspectorGadgetSqlModule './azure_databases_inspectorgadget_sql.bicep' = 
     inspectorGadgetSqlDatabaseName: inspectorGadgetSqlDatabaseName
     inspectorGadgetSqlServerName: inspectorGadgetSqlServerName
     inspectorGadgetSqlServerPrivateEndpointName: inspectorGadgetSqlServerPrivateEndpointName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     privateEndpointSubnetId: virtualNetwork002::privateEndpointSubnet.id
   }

--- a/deployments/azure_databases/azure_databases_adeapp_sql.bicep
+++ b/deployments/azure_databases/azure_databases_adeapp_sql.bicep
@@ -25,6 +25,12 @@ param appConfigResourceGroupName string
 @description('The ID of the Azure Sql Private Dns Zone.')
 param azureSqlPrivateDnsZoneId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -94,105 +100,59 @@ resource adeAppSqlDatabaseDiagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${adeAppSqlDatabase.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'SqlInsights'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AutomaticTuning'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'QueryStoreRuntimeStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'QueryStoreWaitStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Errors'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DatabaseWaitStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Timeouts'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Blocks'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Deadlocks'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Basic'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'InstanceAndAppAdvanced'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'WorkloadManagement'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -225,9 +185,6 @@ resource adeAppSqlServerPrivateEndpoint 'Microsoft.Network/privateEndpoints@2020
 //////////////////////////////////////////////////
 resource azureSqlprivateEndpointDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
   name: '${adeAppSqlServerPrivateEndpoint.name}/dnsgroupname'
-  dependsOn: [
-    adeAppSqlServerPrivateEndpoint
-  ]
   properties: {
     privateDnsZoneConfigs: [
       {

--- a/deployments/azure_databases/azure_databases_inspectorgadget_sql.bicep
+++ b/deployments/azure_databases/azure_databases_inspectorgadget_sql.bicep
@@ -10,6 +10,12 @@ param adminUserName string
 @description('The ID of the Azure Sql Private Dns Zone.')
 param azureSqlPrivateDnsZoneId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The name of the Inspector Gadget Sql Database.')
 param inspectorGadgetSqlDatabaseName string
 
@@ -77,105 +83,59 @@ resource inspectorGadgetSqlDatabaseDiagnostics 'microsoft.insights/diagnosticSet
   name: '${inspectorGadgetSqlDatabase.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'SqlInsights'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AutomaticTuning'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'QueryStoreRuntimeStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'QueryStoreWaitStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Errors'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DatabaseWaitStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Timeouts'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Blocks'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Deadlocks'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Basic'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'InstanceAndAppAdvanced'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'WorkloadManagement'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -208,9 +168,6 @@ resource inspectorGadgetSqlServerPrivateEndpoint 'Microsoft.Network/privateEndpo
 //////////////////////////////////////////////////
 resource azureSqlprivateEndpointDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
   name: '${inspectorGadgetSqlServerPrivateEndpoint.name}/dnsgroupname'
-  dependsOn: [
-    inspectorGadgetSqlServerPrivateEndpoint
-  ]
   properties: {
     privateDnsZoneConfigs: [
       {

--- a/deployments/azure_frontend_load_balancers/azure_application_gateway.bicep
+++ b/deployments/azure_frontend_load_balancers/azure_application_gateway.bicep
@@ -42,6 +42,12 @@ param applicationGatewayPublicIpAddressName string
 @description('The ID of the Application Gateway Subnet')
 param applicationGatewaySubnetId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The Fqdn of the Inspector Gadget App Service.')
 param inspectorGadgetAppServiceFqdn string
 
@@ -221,41 +227,27 @@ resource applicationGatewayPublicIpAddressDiagnostics 'Microsoft.insights/diagno
   name: '${applicationGatewayPublicIpAddress.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'DDoSProtectionNotifications'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationFlowLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationReports'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -302,7 +294,7 @@ resource inspectorGadgetWafPolicy 'Microsoft.Network/ApplicationGatewayWebApplic
       managedRuleSets: [
         {
           ruleSetType: 'OWASP'
-          ruleSetVersion: '3.0'
+          ruleSetVersion: '3.1'
           ruleGroupOverrides: []
         }
       ]
@@ -1292,41 +1284,27 @@ resource applicationGatewayDiagnostics 'Microsoft.insights/diagnosticSettings@20
   name: '${applicationGateway.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'ApplicationGatewayAccessLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'ApplicationGatewayPerformanceLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'ApplicationGatewayFirewallLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_frontend_load_balancers/azure_application_gateway.bicep
+++ b/deployments/azure_frontend_load_balancers/azure_application_gateway.bicep
@@ -294,7 +294,7 @@ resource inspectorGadgetWafPolicy 'Microsoft.Network/ApplicationGatewayWebApplic
       managedRuleSets: [
         {
           ruleSetType: 'OWASP'
-          ruleSetVersion: '3.1'
+          ruleSetVersion: '3.0'
           ruleGroupOverrides: []
         }
       ]

--- a/deployments/azure_frontend_load_balancers/azure_frontend_load_balancers.bicep
+++ b/deployments/azure_frontend_load_balancers/azure_frontend_load_balancers.bicep
@@ -26,6 +26,8 @@ var adeAppVmResourceGroupName = 'rg-ade-${aliasRegion}-adeappvm'
 var adeAppVmssResourceGroupName = 'rg-ade-${aliasRegion}-adeappvmss'
 var appConfigResourceGroupName = 'rg-ade-${aliasRegion}-appconfig'
 var containerRegistryResourceGroupName = 'rg-ade-${aliasRegion}-containerregistry'
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var identityResourceGroupName = 'rg-ade-${aliasRegion}-identity'
 var keyVaultResourceGroupName = 'rg-ade-${aliasRegion}-keyvault'
 var monitorResourceGroupName = 'rg-ade-${aliasRegion}-monitor'
@@ -105,6 +107,20 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
   name: logAnalyticsWorkspaceName
 }
 
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
+}
+
 // Existing Resource - Managed Identity
 //////////////////////////////////////////////////
 resource applicationGatewayManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' existing = {
@@ -155,6 +171,8 @@ module applicationGatewayModule 'azure_application_gateway.bicep' = {
     applicationGatewayName: applicationGatewayName
     applicationGatewayPublicIpAddressName: applicationGatewayPublicIpAddressName
     applicationGatewaySubnetId: virtualNetwork001::applicationGatewaySubnet.id
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     inspectorGadgetAppServiceFqdn: inspectorGadgetAppServiceFqdn
     inspectorGadgetAppServiceHostName: inspectorGadgetAppServiceHostName
     inspectorGadgetAppServiceWafPolicyName: inspectorGadgetAppServiceWafPolicyName
@@ -178,6 +196,8 @@ module adeWebVmNICUpdateModule './azure_virtual_machine_adeweb_vm_nic_update.bic
     adeAppFrontendVmBackendPoolId: applicationGatewayModule.outputs.adeAppFrontendVmBackendPoolId
     adeWebVirtualMachines: adeWebVirtualMachines
     adeWebVmSubnetId: virtualNetwork002::adeWebVmSubnet.id
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }

--- a/deployments/azure_frontend_load_balancers/azure_virtual_machine_adeweb_vm_nic_update.bicep
+++ b/deployments/azure_frontend_load_balancers/azure_virtual_machine_adeweb_vm_nic_update.bicep
@@ -18,6 +18,12 @@ param adeAppFrontendVmBackendPoolId string
 @description('The ID of the ADE Web Virtual Machine subnet.')
 param adeWebVmSubnetId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -72,15 +78,13 @@ resource adeWebVmNicDiagnosticSetting 'microsoft.insights/diagnosticSettings@202
   name: '${adeWebVirtualMachine.nicName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_governance/azure_activity_log.bicep
+++ b/deployments/azure_governance/azure_activity_log.bicep
@@ -24,8 +24,6 @@ resource subscriptionActivityLog 'Microsoft.Insights/diagnosticSettings@2021-05-
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_activity_log.bicep
+++ b/deployments/azure_governance/azure_activity_log.bicep
@@ -7,6 +7,12 @@ targetScope = 'subscription'
 @description('The name of the Activity Log Diagnostic Settings.')
 param activityLogDiagnosticSettingsName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -16,6 +22,10 @@ resource subscriptionActivityLog 'Microsoft.Insights/diagnosticSettings@2021-05-
   name: activityLogDiagnosticSettingsName
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_app_config.bicep
+++ b/deployments/azure_governance/azure_app_config.bicep
@@ -3,6 +3,12 @@
 @description('The name of the App Configuration.')
 param appConfigName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -33,33 +39,25 @@ resource appConfigDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-
   name: '${appConfig.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'HttpRequest'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'Audit'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_governance/azure_app_config.bicep
+++ b/deployments/azure_governance/azure_app_config.bicep
@@ -41,8 +41,6 @@ resource appConfigDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_application_insights.bicep
+++ b/deployments/azure_governance/azure_application_insights.bicep
@@ -3,6 +3,12 @@
 @description('The name of the Application Insights instance.')
 param applicationInsightsName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -35,105 +41,61 @@ resource applicationInsightsDiagnostics 'microsoft.insights/diagnosticSettings@2
   name: '${applicationInsights.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'AppAvailabilityResults'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppBrowserTimings'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppEvents'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppDependencies'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppExceptions'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppPageViews'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppPerformanceCounters'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppRequests'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppSystemEvents'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppTraces'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_governance/azure_application_insights.bicep
+++ b/deployments/azure_governance/azure_application_insights.bicep
@@ -43,8 +43,6 @@ resource applicationInsightsDiagnostics 'microsoft.insights/diagnosticSettings@2
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_event_hub.bicep
+++ b/deployments/azure_governance/azure_event_hub.bicep
@@ -66,8 +66,6 @@ resource eventHubNamespaceDiagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${eventHubNamespace.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_event_hub.bicep
+++ b/deployments/azure_governance/azure_event_hub.bicep
@@ -1,0 +1,121 @@
+// Parameters
+//////////////////////////////////////////////////
+@description('The name of the Event Hub.')
+param eventHubName string
+
+@description('The name of the Event Hub Namespace.')
+param eventHubNamespaceName string
+
+@description('The ID of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceId string
+
+// Variables
+//////////////////////////////////////////////////
+var location = resourceGroup().location
+var tags = {
+  environment: 'production'
+  function: 'monitoring and diagnostics'
+  costCenter: 'it'
+}
+
+// Resource - Event Hub Namespace
+//////////////////////////////////////////////////
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
+  name: eventHubNamespaceName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Basic'
+    tier: 'Basic'
+    capacity: 1
+  }
+  properties: {
+    isAutoInflateEnabled: false
+    zoneRedundant: true
+    maximumThroughputUnits: 0
+  }
+}
+
+// Resource - Event Hub
+//////////////////////////////////////////////////
+resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
+  name: '${eventHubNamespace.name}/${eventHubName}'
+  properties: {
+    messageRetentionInDays: 7
+    partitionCount: 1
+  }
+}
+
+// Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' = {
+  name: '${eventHubNamespace.name}/RootManageSharedAccessKey'
+  properties: {
+    rights: [
+      'Listen'
+      'Manage'
+      'Send'
+    ]
+  }
+}
+
+// Resource - Event Hub Namespace - Diagnostic Settings
+//////////////////////////////////////////////////
+resource eventHubNamespaceDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
+  scope: eventHubNamespace
+  name: '${eventHubNamespace.name}-diagnostics'
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    logAnalyticsDestinationType: 'Dedicated'
+    logs: [
+      {
+        category: 'ArchiveLogs'
+        enabled: true
+      }
+      {
+        category: 'OperationalLogs'
+        enabled: true
+      }
+      {
+        category: 'AutoScaleLogs'
+        enabled: true
+      }
+      {
+        category: 'KafkaCoordinatorLogs'
+        enabled: true
+      }
+      {
+        category: 'KafkaUserErrorLogs'
+        enabled: true
+      }
+      {
+        category: 'EventHubVNetConnectionEvent'
+        enabled: true
+      }
+      {
+        category: 'CustomerManagedKeyUserLogs'
+        enabled: true
+      }
+      {
+        category: 'RuntimeAuditLogs'
+        enabled: true
+      }
+      {
+        category: 'ApplicationMetricsLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+// Outputs
+//////////////////////////////////////////////////
+output eventHubNamespaceAuthorizationRuleId string = eventHubNamespaceAuthorizationRule.id

--- a/deployments/azure_governance/azure_event_hub.bicep
+++ b/deployments/azure_governance/azure_event_hub.bicep
@@ -41,8 +41,8 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
 resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
   name: '${eventHubNamespace.name}/${eventHubName}'
   properties: {
-    messageRetentionInDays: 7
-    partitionCount: 1
+    messageRetentionInDays: 1
+    partitionCount: 2
   }
 }
 

--- a/deployments/azure_governance/azure_governance.bicep
+++ b/deployments/azure_governance/azure_governance.bicep
@@ -46,7 +46,7 @@ var containerRegistryManagedIdentityName = 'id-ade-${aliasRegion}-containerregis
 var diagnosticsEventHubName = 'diagnostics'
 var diagnosticsEventHubNamespaceName = 'evh-ade-${aliasRegion}-diagnostics'
 var diagnosticsStorageAccount = {
-  accessTier: 'Archive'
+  accessTier: 'Cool'
   kind: 'StorageV2'
   name: replace('sa-ade-${aliasRegion}-diags', '-', '')
   sku: 'Standard_LRS'
@@ -55,7 +55,7 @@ var initiativeDefinitionName = 'policy-ade-${aliasRegion}-adeinitiative'
 var keyVaultName = 'kv-ade-${aliasRegion}-001'
 var logAnalyticsWorkspaceName = 'log-ade-${aliasRegion}-001'
 var nsgFlowLogsStorageAccount = {
-  accessTier: 'Archive'
+  accessTier: 'Hot'
   kind: 'StorageV2'
   name: replace('sa-ade-${aliasRegion}-nsgflow', '-', '')
   sku: 'Standard_LRS'

--- a/deployments/azure_governance/azure_governance.bicep
+++ b/deployments/azure_governance/azure_governance.bicep
@@ -43,10 +43,23 @@ var appConfigName = 'appcs-ade-${aliasRegion}-001'
 var applicationGatewayManagedIdentityName = 'id-ade-${aliasRegion}-applicationgateway'
 var applicationInsightsName = 'appinsights-ade-${aliasRegion}-001'
 var containerRegistryManagedIdentityName = 'id-ade-${aliasRegion}-containerregistry'
+var diagnosticsEventHubName = 'diagnostics'
+var diagnosticsEventHubNamespaceName = 'evh-ade-${aliasRegion}-diagnostics'
+var diagnosticsStorageAccount = {
+  accessTier: 'Archive'
+  kind: 'StorageV2'
+  name: replace('sa-ade-${aliasRegion}-diags', '-', '')
+  sku: 'Standard_LRS'
+}
 var initiativeDefinitionName = 'policy-ade-${aliasRegion}-adeinitiative'
 var keyVaultName = 'kv-ade-${aliasRegion}-001'
 var logAnalyticsWorkspaceName = 'log-ade-${aliasRegion}-001'
-var nsgFlowLogsStorageAccountName = replace('saade${aliasRegion}nsgflow', '-', '')
+var nsgFlowLogsStorageAccount = {
+  accessTier: 'Archive'
+  kind: 'StorageV2'
+  name: replace('sa-ade-${aliasRegion}-nsgflow', '-', '')
+  sku: 'Standard_LRS'
+}
 
 // Resource Group - App Configuration
 //////////////////////////////////////////////////
@@ -106,6 +119,55 @@ module logAnalyticsModule './azure_log_analytics.bicep' = {
   }
 }
 
+// Module - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+module storageAccountDiagnosticsModule './azure_storage_accounts.bicep' = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: 'storageAccountDiagnosticsDeployment'
+  dependsOn: [
+    monitorResourceGroup
+  ]
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
+    storageAccountAccessTier: diagnosticsStorageAccount.accessTier
+    storageAccountKind: diagnosticsStorageAccount.kind
+    storageAccountName: diagnosticsStorageAccount.name
+    storageAccountSku: diagnosticsStorageAccount.sku
+  }
+}
+
+// Module - Storage Account - NSG Flow Logs
+//////////////////////////////////////////////////
+module storageAccountNsgFlowLogsModule './azure_storage_accounts.bicep' = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: 'storageAccountNsgFlowLogsDeployment'
+  dependsOn: [
+    monitorResourceGroup
+  ]
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
+    storageAccountAccessTier: nsgFlowLogsStorageAccount.accessTier
+    storageAccountKind: nsgFlowLogsStorageAccount.kind
+    storageAccountName: nsgFlowLogsStorageAccount.name
+    storageAccountSku: nsgFlowLogsStorageAccount.sku
+  }
+}
+
+// Module - Event Hub
+//////////////////////////////////////////////////
+module eventHubDiagnosticsModule './azure_event_hub.bicep' = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: 'eventHubDiagnosticsDeployment'
+  dependsOn: [
+    monitorResourceGroup
+  ]
+  params: {
+    eventHubName: diagnosticsEventHubName
+    eventHubNamespaceName: diagnosticsEventHubNamespaceName
+    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId   
+  }
+}
+
 // Module - App Configuration
 //////////////////////////////////////////////////
 module appConfigModule './azure_app_config.bicep' = {
@@ -116,7 +178,9 @@ module appConfigModule './azure_app_config.bicep' = {
   ]
   params: {
     appConfigName: appConfigName
-    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
+    diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
+    eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId
+    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId    
   }
 }
 
@@ -130,6 +194,8 @@ module applicationInsightsModule './azure_application_insights.bicep' = {
   ]
   params: {
     applicationInsightsName: applicationInsightsName
+    diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
+    eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId
     logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
   }
 }
@@ -145,20 +211,6 @@ module appConfigApplicationInsightsModule './azure_app_config_application_insigh
   }
 }
 
-// Module - Storage Account Diagnostics
-//////////////////////////////////////////////////
-module storageAccountDiagnosticsModule './azure_storage_account_diagnostics.bicep' = {
-  scope: resourceGroup(monitorResourceGroupName)
-  name: 'storageAccountDiagnosticsDeployment'
-  dependsOn: [
-    monitorResourceGroup
-  ]
-  params: {
-    logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
-    nsgFlowLogsStorageAccountName: nsgFlowLogsStorageAccountName
-  }
-}
-
 // Module - Activity Log
 //////////////////////////////////////////////////
 module activityLogModule './azure_activity_log.bicep' = {
@@ -166,6 +218,8 @@ module activityLogModule './azure_activity_log.bicep' = {
   name: 'activityLogDeployment'
   params: {
     activityLogDiagnosticSettingsName: activityLogDiagnosticSettingsName
+    diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
+    eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId
     logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
   }
 }
@@ -210,6 +264,8 @@ module keyVaultModule './azure_key_vault.bicep' = {
     applicationGatewayManagedIdentityPrincipalID: identityModule.outputs.applicationGatewayManagedIdentityPrincipalId
     azureActiveDirectoryUserID: azureActiveDirectoryUserID
     containerRegistryManagedIdentityPrincipalID: identityModule.outputs.containerRegistryManagedIdentityPrincipalId
+    diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
+    eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId
     keyVaultName: keyVaultName
     logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
   }

--- a/deployments/azure_governance/azure_key_vault.bicep
+++ b/deployments/azure_governance/azure_key_vault.bicep
@@ -119,8 +119,6 @@ resource keyVaultDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-p
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_governance/azure_key_vault.bicep
+++ b/deployments/azure_governance/azure_key_vault.bicep
@@ -9,6 +9,12 @@ param applicationGatewayManagedIdentityPrincipalID string
 @description('The Service Principal Name ID of the Container Registry Managed Identity.')
 param containerRegistryManagedIdentityPrincipalID string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The name of the Key Vault.')
 param keyVaultName string
 
@@ -111,25 +117,21 @@ resource keyVaultDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-p
   name: '${keyVault.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'AuditEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_governance/azure_log_analytics.bicep
+++ b/deployments/azure_governance/azure_log_analytics.bicep
@@ -43,9 +43,6 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
 resource solutionsContainerInsights 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
   name: '${containerInsights.name}'
   location: location
-  dependsOn: [
-    logAnalyticsWorkspace
-  ]
   properties: {
     workspaceResourceId: logAnalyticsWorkspace.id
   }
@@ -62,9 +59,6 @@ resource solutionsContainerInsights 'Microsoft.OperationsManagement/solutions@20
 resource solutionsKeyVaultAnalytics 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
   name: '${keyVaultAnalytics.name}'
   location: location
-  dependsOn: [
-    logAnalyticsWorkspace
-  ]
   properties: {
     workspaceResourceId: logAnalyticsWorkspace.id
   }
@@ -81,9 +75,6 @@ resource solutionsKeyVaultAnalytics 'Microsoft.OperationsManagement/solutions@20
 resource solutionsVMInsights 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
   name: '${vmInsights.name}'
   location: location
-  dependsOn: [
-    logAnalyticsWorkspace
-  ]
   properties: {
     workspaceResourceId: logAnalyticsWorkspace.id
   }
@@ -107,20 +98,12 @@ resource logAnalyticsWorkspaceDiagnostics 'microsoft.insights/diagnosticSettings
       {
         category: 'Audit'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_governance/azure_storage_accounts.bicep
+++ b/deployments/azure_governance/azure_storage_accounts.bicep
@@ -3,8 +3,17 @@
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
-@description('The name of the NSG Flow Logs Storage Account.')
-param nsgFlowLogsStorageAccountName string
+@description('The Access Tier of the Storage Account.')
+param storageAccountAccessTier string
+
+@description('The Kind of the Storage Account.')
+param storageAccountKind string
+
+@description('The name of the Storage Account.')
+param storageAccountName string
+
+@description('The SKU of the Storage Account.')
+param storageAccountSku string
 
 // Variables
 //////////////////////////////////////////////////
@@ -15,18 +24,18 @@ var tags = {
   costCenter: 'it'
 }
 
-// Resource - Storage Account - Nsg Flow Logs
+// Resource - Storage Account
 //////////////////////////////////////////////////
-resource nsgFlowLogsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
-  name: nsgFlowLogsStorageAccountName
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
+  name: storageAccountName
   location: location
   tags: tags
-  kind: 'StorageV2'
+  kind: storageAccountKind
   sku: {
-    name: 'Standard_RAGRS'
+    name: storageAccountSku
   }
   properties: {
-    accessTier: 'Hot'
+    accessTier: storageAccountAccessTier
     supportsHttpsTrafficOnly: true
   }
   resource blobServices 'blobServices@2021-01-01' = {
@@ -46,20 +55,17 @@ resource nsgFlowLogsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01
 // Resource - Storage Account - Diagnostic Settings
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccountDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
-  scope: nsgFlowLogsStorageAccount
-  name: '${nsgFlowLogsStorageAccount.name}-diagnostics'
+  scope: storageAccount
+  name: '${storageAccount.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
-
     metrics: [
       {
         category: 'Transaction'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -68,45 +74,31 @@ resource nsgFlowLogsStorageAccountDiagnostics 'microsoft.insights/diagnosticSett
 // Resource - Storage Account - Blob - Diagnostic Settings
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccountBlobDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
-  scope: nsgFlowLogsStorageAccount::blobServices
-  name: '${nsgFlowLogsStorageAccount.name}-blob-diagnostics'
+  scope: storageAccount::blobServices
+  name: '${storageAccount.name}-blob-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'StorageRead'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageWrite'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageDelete'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Transaction'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -115,45 +107,31 @@ resource nsgFlowLogsStorageAccountBlobDiagnostics 'microsoft.insights/diagnostic
 // Resource - Storage Account - Table - Diagnostic Settings
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccountTableDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
-  scope: nsgFlowLogsStorageAccount::tableServices
-  name: '${nsgFlowLogsStorageAccount.name}-table-diagnostics'
+  scope: storageAccount::tableServices
+  name: '${storageAccount.name}-table-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'StorageRead'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageWrite'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageDelete'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Transaction'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -162,45 +140,31 @@ resource nsgFlowLogsStorageAccountTableDiagnostics 'microsoft.insights/diagnosti
 // Resource - Storage Account - File - Diagnostic Settings
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccountFileDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
-  scope: nsgFlowLogsStorageAccount::fileServices
-  name: '${nsgFlowLogsStorageAccount.name}-file-diagnostics'
+  scope: storageAccount::fileServices
+  name: '${storageAccount.name}-file-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'StorageRead'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageWrite'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageDelete'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Transaction'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -209,46 +173,36 @@ resource nsgFlowLogsStorageAccountFileDiagnostics 'microsoft.insights/diagnostic
 // Resource - Storage Account - Queue - Diagnostic Settings
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccountQueueDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
-  scope: nsgFlowLogsStorageAccount::queueServices
-  name: '${nsgFlowLogsStorageAccount.name}-queue-diagnostics'
+  scope: storageAccount::queueServices
+  name: '${storageAccount.name}-queue-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'StorageRead'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageWrite'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'StorageDelete'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'Transaction'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
 }
+
+// Outputs
+//////////////////////////////////////////////////
+output diagnosticsStorageAccountId string = storageAccount.id

--- a/deployments/azure_governance/azure_storage_accounts.bicep
+++ b/deployments/azure_governance/azure_storage_accounts.bicep
@@ -59,8 +59,6 @@ resource nsgFlowLogsStorageAccountDiagnostics 'microsoft.insights/diagnosticSett
   name: '${storageAccount.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
@@ -78,8 +76,6 @@ resource nsgFlowLogsStorageAccountBlobDiagnostics 'microsoft.insights/diagnostic
   name: '${storageAccount.name}-blob-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -111,8 +107,6 @@ resource nsgFlowLogsStorageAccountTableDiagnostics 'microsoft.insights/diagnosti
   name: '${storageAccount.name}-table-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -144,8 +138,6 @@ resource nsgFlowLogsStorageAccountFileDiagnostics 'microsoft.insights/diagnostic
   name: '${storageAccount.name}-file-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -177,8 +169,6 @@ resource nsgFlowLogsStorageAccountQueueDiagnostics 'microsoft.insights/diagnosti
   name: '${storageAccount.name}-queue-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_networking/azure_bastion.bicep
+++ b/deployments/azure_networking/azure_bastion.bicep
@@ -50,8 +50,6 @@ resource azureBastionPublicIpAddressDiagnostics 'microsoft.insights/diagnosticSe
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -106,8 +104,6 @@ resource azureBastionDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-
   name: '${azureBastion.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'

--- a/deployments/azure_networking/azure_bastion.bicep
+++ b/deployments/azure_networking/azure_bastion.bicep
@@ -9,6 +9,12 @@ param azureBastionPublicIpAddressName string
 @description('The ID of the Azure Bastion Subnet.')
 param azureBastionSubnetId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -42,41 +48,29 @@ resource azureBastionPublicIpAddressDiagnostics 'microsoft.insights/diagnosticSe
   name: '${azureBastionPublicIpAddress.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'DDoSProtectionNotifications'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationFlowLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationReports'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -112,25 +106,21 @@ resource azureBastionDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-
   name: '${azureBastion.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'BastionAuditLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_firewall.bicep
+++ b/deployments/azure_networking/azure_firewall.bicep
@@ -50,8 +50,6 @@ resource azureFirewallPublicIpAddressDiagnostics 'Microsoft.Insights/diagnosticS
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -154,8 +152,6 @@ resource azureFirewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05
   name: '${azureFirewall.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'

--- a/deployments/azure_networking/azure_firewall.bicep
+++ b/deployments/azure_networking/azure_firewall.bicep
@@ -9,6 +9,12 @@ param azureFirewallPublicIpAddressName string
 @description('The ID of the Azure Firewall Subnet.')
 param azureFirewallSubnetId string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -42,41 +48,29 @@ resource azureFirewallPublicIpAddressDiagnostics 'Microsoft.Insights/diagnosticS
   name: '${azureFirewallPublicIpAddress.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'DDoSProtectionNotifications'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationFlowLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationReports'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -160,41 +154,29 @@ resource azureFirewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05
   name: '${azureFirewall.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'AzureFirewallApplicationRule'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AzureFirewallNetworkRule'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AzureFirewallDnsProxy'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_network_security_group.bicep
+++ b/deployments/azure_networking/azure_network_security_group.bicep
@@ -15,6 +15,12 @@ param adeWebVmSubnetNSGName string
 @description('The name of the Azure Bastion Subnet NSG.')
 param azureBastionSubnetNSGName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -111,23 +117,19 @@ resource azureBastionSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings
   name: '${azureBastionSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -166,23 +168,19 @@ resource managementSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
   name: '${managementSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -206,23 +204,19 @@ resource adeWebVmSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${adeWebVmSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -246,23 +240,19 @@ resource adeAppVmSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${adeAppVmSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -286,23 +276,19 @@ resource adeWebVmssSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
   name: '${adeWebVmssSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -326,23 +312,19 @@ resource adeAppVmssSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
   name: '${adeAppVmssSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'NetworkSecurityGroupEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'NetworkSecurityGroupRuleCounter'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_network_security_group.bicep
+++ b/deployments/azure_networking/azure_network_security_group.bicep
@@ -119,8 +119,6 @@ resource azureBastionSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -170,8 +168,6 @@ resource managementSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -204,8 +200,6 @@ resource adeWebVmSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${adeWebVmSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
@@ -242,8 +236,6 @@ resource adeAppVmSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@202
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -278,8 +270,6 @@ resource adeWebVmssSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -312,8 +302,6 @@ resource adeAppVmssSubnetNSGDiagnostics 'microsoft.insights/diagnosticSettings@2
   name: '${adeAppVmssSubnetNSG.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'

--- a/deployments/azure_networking/azure_networking.bicep
+++ b/deployments/azure_networking/azure_networking.bicep
@@ -57,6 +57,8 @@ var azureFirewallSubnetName = 'AzureFirewallSubnet'
 var azureFirewallSubnetPrefix = '10.101.1.0/24'
 var azureSQLprivateDnsZoneName = 'privatelink${environment().suffixes.sqlServerHostname}'
 var connectionName = 'cn-ade-${aliasRegion}-vgw001'
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var gatewaySubnetName = 'GatewaySubnet'
 var gatewaySubnetPrefix = '10.101.255.0/24'
 var internetRouteTableName = 'route-ade-${aliasRegion}-internet'
@@ -95,11 +97,25 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
   name: logAnalyticsWorkspaceName
 }
 
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
 // Existing Resource - Storage Account - NSG Flow Logs
 //////////////////////////////////////////////////
 resource nsgFlowLogsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
   scope: resourceGroup(monitorResourceGroupName)
   name: nsgFlowLogsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
 }
 
 // Resource Group - Networking
@@ -137,6 +153,8 @@ module networkSecurityGroupsModule './azure_network_security_group.bicep' = {
     adeWebVmssSubnetNSGName: adeWebVmssSubnetNSGName
     adeWebVmSubnetNSGName: adeWebVmSubnetNSGName
     azureBastionSubnetNSGName: azureBastionSubnetNSGName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     managementSubnetNSGName: managementSubnetNSGName
     sourceAddressPrefix: sourceAddressPrefix
@@ -172,6 +190,8 @@ module virtualNetwork001Module './azure_virtual_network_001.bicep' = {
     azureBastionSubnetPrefix: azureBastionSubnetPrefix
     azureFirewallSubnetName: azureFirewallSubnetName
     azureFirewallSubnetPrefix: azureFirewallSubnetPrefix
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     gatewaySubnetName: gatewaySubnetName
     gatewaySubnetPrefix: gatewaySubnetPrefix
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
@@ -206,6 +226,8 @@ module virtualNetwork002Module './azure_virtual_network_002.bicep' = {
     adeWebVmSubnetName: adeWebVmSubnetName
     adeWebVmSubnetNSGId: networkSecurityGroupsModule.outputs.adeWebVmSubnetNSGId
     adeWebVmSubnetPrefix: adeWebVmSubnetPrefix
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     natGatewayId: natGatewayModule.outputs.natGatewayId
     privateEndpointSubnetName: privateEndpointSubnetName
@@ -229,6 +251,8 @@ module azureFirewallModule './azure_firewall.bicep' = if (deployAzureFirewall ==
     azureFirewallName: azureFirewallName
     azureFirewallPublicIpAddressName: azureFirewallPublicIpAddressName
     azureFirewallSubnetId: virtualNetwork001Module.outputs.azureFirewallSubnetId
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -245,6 +269,8 @@ module azureBastionModule './azure_bastion.bicep' = {
     azureBastionName: azureBastionName
     azureBastionPublicIpAddressName: azureBastionPublicIpAddressName
     azureBastionSubnetId: virtualNetwork001Module.outputs.azureBastionSubnetId
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -260,6 +286,8 @@ module azureVpnGatewayModule './azure_vpn_gateway.bicep' = if (deployVpnGateway 
   params: {
     connectionName: connectionName
     connectionSharedKey: keyVault.getSecret('resourcePassword')
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     gatewaySubnetId: virtualNetwork001Module.outputs.gatewaySubnetId
     localNetworkGatewayAddressPrefix: localNetworkGatewayAddressPrefix
     localNetworkGatewayName: localNetworkGatewayName

--- a/deployments/azure_networking/azure_virtual_network_001.bicep
+++ b/deployments/azure_networking/azure_virtual_network_001.bicep
@@ -21,6 +21,12 @@ param azureFirewallSubnetName string
 @description('The address prefix of the Azure Firewall Subnet.')
 param azureFirewallSubnetPrefix string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The name of the Gateway Subnet.')
 param gatewaySubnetName string
 
@@ -119,25 +125,21 @@ resource virtualNetwork001Diagnostics 'microsoft.insights/diagnosticSettings@202
   name: '${virtualNetwork001.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'VMProtectionAlerts'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_virtual_network_001.bicep
+++ b/deployments/azure_networking/azure_virtual_network_001.bicep
@@ -127,8 +127,6 @@ resource virtualNetwork001Diagnostics 'microsoft.insights/diagnosticSettings@202
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_networking/azure_virtual_network_002.bicep
+++ b/deployments/azure_networking/azure_virtual_network_002.bicep
@@ -191,8 +191,6 @@ resource virtualNetwork002Diagnostics 'microsoft.insights/diagnosticSettings@202
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {

--- a/deployments/azure_networking/azure_virtual_network_002.bicep
+++ b/deployments/azure_networking/azure_virtual_network_002.bicep
@@ -42,6 +42,12 @@ param adeWebVmSubnetNSGId string
 @description('The address prefix of the ADE Web Vm Subnet.')
 param adeWebVmSubnetPrefix string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -183,25 +189,21 @@ resource virtualNetwork002Diagnostics 'microsoft.insights/diagnosticSettings@202
   scope: virtualNetwork002
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'VMProtectionAlerts'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_vpn_gateway.bicep
+++ b/deployments/azure_networking/azure_vpn_gateway.bicep
@@ -7,6 +7,12 @@ param connectionName string
 @secure()
 param connectionSharedKey string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Gateway Subnet.')
 param gatewaySubnetId string
 
@@ -55,41 +61,29 @@ resource vpnGatewayPublicIpAddressDiagnostics 'microsoft.insights/diagnosticSett
   name: '${vpnGatewayPublicIpAddress.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'DDoSProtectionNotifications'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationFlowLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationReports'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -147,57 +141,37 @@ resource vpnGatewayDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01
   name: '${vpnGateway.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'GatewayDiagnosticLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'TunnelDiagnosticLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'RouteDiagnosticLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'IKEDiagnosticLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'P2SDiagnosticLog'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_networking/azure_vpn_gateway.bicep
+++ b/deployments/azure_networking/azure_vpn_gateway.bicep
@@ -63,8 +63,6 @@ resource vpnGatewayPublicIpAddressDiagnostics 'microsoft.insights/diagnosticSett
     workspaceId: logAnalyticsWorkspaceId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
@@ -141,8 +139,6 @@ resource vpnGatewayDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01
   name: '${vpnGateway.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    storageAccountId: diagnosticsStorageAccountId
-    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     storageAccountId: diagnosticsStorageAccountId
     eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'

--- a/deployments/azure_virtual_machines/azure_load_balancers_adeapp_vm.bicep
+++ b/deployments/azure_virtual_machines/azure_load_balancers_adeapp_vm.bicep
@@ -12,6 +12,12 @@ param adeAppVmSubnetId string
 @description('Array of backend services for ADE App.')
 param backendServices array
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -89,33 +95,23 @@ resource adeAppVmLoadBalancerDiagnostics 'microsoft.insights/diagnosticSettings@
   name: '${adeAppVmLoadBalancer.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'LoadBalancerAlertEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'LoadBalancerProbeHealthStatus'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines/azure_load_balancers_adeapp_vmss.bicep
+++ b/deployments/azure_virtual_machines/azure_load_balancers_adeapp_vmss.bicep
@@ -12,6 +12,12 @@ param adeAppVmssSubnetId string
 @description('Array of backend services for ADE App.')
 param backendServices array
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -89,33 +95,23 @@ resource adeAppVmssLoadBalancerDiagnostics 'microsoft.insights/diagnosticSetting
   name: '${adeAppVmssLoadBalancer.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'LoadBalancerAlertEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'LoadBalancerProbeHealthStatus'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines/azure_virtual_machines.bicep
+++ b/deployments/azure_virtual_machines/azure_virtual_machines.bicep
@@ -121,6 +121,8 @@ var backendServices = [
     port: 5003
   }
 ]
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var jumpboxName = 'vm-jumpbox01'
 var jumpboxNICName = 'nic-ade-${aliasRegion}-jumpbox01'
 var jumpboxOSDiskName = 'osdisk-ade-${aliasRegion}-jumpbox01'
@@ -146,6 +148,20 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
   scope: resourceGroup(monitorResourceGroupName)
   name: logAnalyticsWorkspaceName
+}
+
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
 }
 
 // Existing Resource - Virtual Network - Virtual Network 001
@@ -216,6 +232,8 @@ module jumpBoxModule './azure_virtual_machines_jumpbox.bicep' = {
   params: {
     adminPassword: keyVault.getSecret('resourcePassword')
     adminUserName: adminUserName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     jumpboxName: jumpboxName
     jumpboxNICName: jumpboxNICName
     jumpboxOSDiskName: jumpboxOSDiskName
@@ -256,6 +274,8 @@ module adeAppVmLoadBalancerModule 'azure_load_balancers_adeapp_vm.bicep' = {
     adeAppVmLoadBalancerPrivateIpAddress: adeAppVmLoadBalancerPrivateIpAddress
     adeAppVmSubnetId: virtualNetwork002::adeAppVmSubnet.id
     backendServices: backendServices
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -273,6 +293,8 @@ module adeAppVmssLoadBalancerModule 'azure_load_balancers_adeapp_vmss.bicep' = {
     adeAppVmssLoadBalancerPrivateIpAddress: adeAppVmssLoadBalancerPrivateIpAddress
     adeAppVmssSubnetId: virtualNetwork002::adeAppVmssSubnet.id
     backendServices: backendServices
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -290,6 +312,8 @@ module adeWebVmModule 'azure_virtual_machines_adeweb_vm.bicep' = {
     adeWebVmSubnetId: virtualNetwork002::adeWebVmSubnet.id
     adminPassword: keyVault.getSecret('resourcePassword')
     adminUserName: adminUserName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceCustomerId: logAnalyticsWorkspace.properties.customerId
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     logAnalyticsWorkspaceKey: listKeys(logAnalyticsWorkspace.id, logAnalyticsWorkspace.apiVersion).primarySharedKey
@@ -310,6 +334,8 @@ module adeAppVmModule 'azure_virtual_machines_adeapp_vm.bicep' = {
     adeAppVmSubnetId: virtualNetwork002::adeAppVmSubnet.id
     adminPassword: keyVault.getSecret('resourcePassword')
     adminUserName: adminUserName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceCustomerId: logAnalyticsWorkspace.properties.customerId
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     logAnalyticsWorkspaceKey: listKeys(logAnalyticsWorkspace.id, logAnalyticsWorkspace.apiVersion).primarySharedKey

--- a/deployments/azure_virtual_machines/azure_virtual_machines_adeapp_vm.bicep
+++ b/deployments/azure_virtual_machines/azure_virtual_machines_adeapp_vm.bicep
@@ -16,6 +16,12 @@ param adminPassword string
 @description('The name of the admin user.')
 param adminUserName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The customer Id of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomerId string
 
@@ -67,15 +73,13 @@ resource adeAppVmNicDiagnosticSetting 'microsoft.insights/diagnosticSettings@202
   name: '${adeAppVirtualMachine.nicName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines/azure_virtual_machines_adeweb_vm.bicep
+++ b/deployments/azure_virtual_machines/azure_virtual_machines_adeweb_vm.bicep
@@ -13,6 +13,12 @@ param adminPassword string
 @description('The name of the admin user.')
 param adminUserName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The customer Id of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomerId string
 
@@ -59,15 +65,13 @@ resource adeWebVmNicDiagnosticSetting 'microsoft.insights/diagnosticSettings@202
   name: '${adeWebVirtualMachine.nicName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines/azure_virtual_machines_jumpbox.bicep
+++ b/deployments/azure_virtual_machines/azure_virtual_machines_jumpbox.bicep
@@ -7,6 +7,12 @@ param adminPassword string
 @description('The name of the admin user.')
 param adminUserName string
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The name of the Jumpbox Virtual Machine.')
 param jumpboxName string
 
@@ -66,41 +72,27 @@ resource jumpboxPublicIpAddressDiagnostics 'microsoft.insights/diagnosticSetting
   name: '${jumpboxPublicIpAddress.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'DDoSProtectionNotifications'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationFlowLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'DDoSMitigationReports'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -137,15 +129,13 @@ resource jumpboxNICDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01
   name: '${jumpboxNIC.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines_app_deployment/azure_load_balancers_adeapp_vm.bicep
+++ b/deployments/azure_virtual_machines_app_deployment/azure_load_balancers_adeapp_vm.bicep
@@ -12,6 +12,12 @@ param adeAppVmSubnetId string
 @description('Array of backend services for ADE App.')
 param backendServices array
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -89,33 +95,23 @@ resource adeAppVmLoadBalancerDiagnostics 'microsoft.insights/diagnosticSettings@
   name: '${adeAppVmLoadBalancer.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'LoadBalancerAlertEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'LoadBalancerProbeHealthStatus'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines_app_deployment/azure_load_balancers_adeapp_vmss.bicep
+++ b/deployments/azure_virtual_machines_app_deployment/azure_load_balancers_adeapp_vmss.bicep
@@ -12,6 +12,12 @@ param adeAppVmssSubnetId string
 @description('Array of backend services for ADE App.')
 param backendServices array
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
 
@@ -89,33 +95,23 @@ resource adeAppVmssLoadBalancerDiagnostics 'microsoft.insights/diagnosticSetting
   name: '${adeAppVmssLoadBalancer.name}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     logs: [
       {
         category: 'LoadBalancerAlertEvent'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'LoadBalancerProbeHealthStatus'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_adeapp_vm_app_deployment.bicep
+++ b/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_adeapp_vm_app_deployment.bicep
@@ -31,6 +31,12 @@ param containerRegistryPassword string
 @description('Function to generate the current time.')
 param currentTime string = utcNow()
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The customer Id of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomerId string
 
@@ -89,15 +95,13 @@ resource adeAppVmNicDiagnosticSetting 'microsoft.insights/diagnosticSettings@202
   name: '${adeAppVirtualMachine.nicName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_adeweb_vm_app_deployment.bicep
+++ b/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_adeweb_vm_app_deployment.bicep
@@ -28,6 +28,12 @@ param containerRegistryPassword string
 @description('Function to generate the current time.')
 param currentTime string = utcNow()
 
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
 @description('The customer Id of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomerId string
 
@@ -81,15 +87,13 @@ resource adeWebVmNicDiagnosticSetting 'microsoft.insights/diagnosticSettings@202
   name: '${adeWebVirtualMachine.nicName}-diagnostics'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
     logAnalyticsDestinationType: 'Dedicated'
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_app_deployment.bicep
+++ b/deployments/azure_virtual_machines_app_deployment/azure_virtual_machines_app_deployment.bicep
@@ -129,6 +129,8 @@ var backendServices = [
   }
 ]
 var containerRegistryName = replace('acr-ade-${aliasRegion}-001', '-', '')
+var eventHubNamespaceAuthorizationRuleName = 'evh-ade-${aliasRegion}-diagnostics/RootManageSharedAccessKey'
+var diagnosticsStorageAccountName = replace('sa-ade-${aliasRegion}-diags', '-', '')
 var keyVaultName = 'kv-ade-${aliasRegion}-001'
 var logAnalyticsWorkspaceName = 'log-ade-${aliasRegion}-001'
 var proximityPlacementGroupAz1Name = 'ppg-ade-${aliasRegion}-adeApp-az1'
@@ -162,6 +164,20 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
   scope: resourceGroup(monitorResourceGroupName)
   name: logAnalyticsWorkspaceName
+}
+
+// Existing Resource - Storage Account - Diagnostics
+//////////////////////////////////////////////////
+resource diagnosticsStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: diagnosticsStorageAccountName
+}
+
+// Existing Resource - Event Hub Authorization Rule
+//////////////////////////////////////////////////
+resource eventHubNamespaceAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2021-11-01' existing = {
+  scope: resourceGroup(monitorResourceGroupName)
+  name: eventHubNamespaceAuthorizationRuleName
 }
 
 // Existing Resource - Virtual Network - Virtual Network 002
@@ -205,6 +221,8 @@ module adeAppVmLoadBalancerModule 'azure_load_balancers_adeapp_vm.bicep' = {
     adeAppVmLoadBalancerPrivateIpAddress: adeAppVmLoadBalancerPrivateIpAddress
     adeAppVmSubnetId: virtualNetwork002::adeAppVmSubnet.id
     backendServices: backendServices
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -219,6 +237,8 @@ module adeAppVmssLoadBalancerModule 'azure_load_balancers_adeapp_vmss.bicep' = {
     adeAppVmssLoadBalancerPrivateIpAddress: adeAppVmssLoadBalancerPrivateIpAddress
     adeAppVmssSubnetId: virtualNetwork002::adeAppVmssSubnet.id
     backendServices: backendServices
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
@@ -237,6 +257,8 @@ module adeWebVmModule 'azure_virtual_machines_adeweb_vm_app_deployment.bicep' = 
     appConfigConnectionString: first(listKeys(appConfig.id, appConfig.apiVersion).value).connectionString
     containerRegistryName: containerRegistryName
     containerRegistryPassword: first(listCredentials(containerRegistry.id, containerRegistry.apiVersion).passwords).value
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceCustomerId: logAnalyticsWorkspace.properties.customerId
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     logAnalyticsWorkspaceKey: listKeys(logAnalyticsWorkspace.id, logAnalyticsWorkspace.apiVersion).primarySharedKey
@@ -259,6 +281,8 @@ module adeAppVmModule 'azure_virtual_machines_adeapp_vm_app_deployment.bicep' = 
     appConfigConnectionString: first(listKeys(appConfig.id, appConfig.apiVersion).value).connectionString
     containerRegistryName: containerRegistryName
     containerRegistryPassword: first(listCredentials(containerRegistry.id, containerRegistry.apiVersion).passwords).value
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     logAnalyticsWorkspaceCustomerId: logAnalyticsWorkspace.properties.customerId
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     logAnalyticsWorkspaceKey: listKeys(logAnalyticsWorkspace.id, logAnalyticsWorkspace.apiVersion).primarySharedKey


### PR DESCRIPTION
Add an Event Hub and Storage Account as part of the Activity Log and Diagnostics Settings

- Created a new Event Hub and Storage Account as part of the Activity Log and Diagnostics Settings
- Configured Activity Log and Diagnostic Settings to use new Event Hub and Storage Account
- Removed retention settings from all Activity Log and Diagnostics Settings