### PR TITLE
Add Diagnostic Settings to App Service Plan Deployment

### DIFF
--- a/src/bicep/azure_app_services/azure_app_config_app_services.bicep
+++ b/src/bicep/azure_app_services/azure_app_config_app_services.bicep
@@ -8,7 +8,7 @@ param appConfigName string
 
 // Resource - App Configuration - Key Virtual Machine Backing Service Connection String
 //////////////////////////////////////////////////
-resource appConfigKeyVirtualMachineBackingServiceConnectionStrings 'Microsoft.AppConfiguration/configurationStores/keyValues@2020-07-01-preview' = [for (adeAppAppService, i) in adeAppAppServices: {
+resource appConfigKeyVirtualMachineBackingServiceConnectionStrings 'Microsoft.AppConfiguration/configurationStores/keyValues@2022-05-01' = [for (adeAppAppService, i) in adeAppAppServices: {
   name: '${appConfigName}/ADE:${adeAppAppService.adeAppName}Uri$appservices'
   properties: {
     value: 'https://${adeAppAppService.adeAppAppServiceName}.azurewebsites.net'

--- a/src/bicep/azure_app_services/azure_app_service_adeapp_webhooks.bicep
+++ b/src/bicep/azure_app_services/azure_app_service_adeapp_webhooks.bicep
@@ -16,7 +16,7 @@ param location string
 //////////////////////////////////////////////////
 
 @batchSize(1)
-resource adeAppWebHook 'Microsoft.ContainerRegistry/registries/webhooks@2019-05-01' = [for (adeAppAppService, i) in adeAppAppServices: {
+resource adeAppWebHook 'Microsoft.ContainerRegistry/registries/webhooks@2021-09-01' = [for (adeAppAppService, i) in adeAppAppServices: {
   name: '${containerRegistryName}/${adeAppAppService.adeAppAppServiceName}'
   location: location
   properties: {

--- a/src/bicep/azure_app_services/azure_app_service_plan.bicep
+++ b/src/bicep/azure_app_services/azure_app_service_plan.bicep
@@ -3,8 +3,17 @@
 @description('The name of the App Service Plan.')
 param appServicePlanName string
 
-@description('The region location of deployment.')
+@description('The ID of the Diagnostics Storage Account.')
+param diagnosticsStorageAccountId string
+
+@description('The ID of the Event Hub Namespace Authorization Rule.')
+param eventHubNamespaceAuthorizationRuleId string
+
+@description('The location for all resources.')
 param location string
+
+@description('The ID of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceId string
 
 // Variables
 //////////////////////////////////////////////////
@@ -16,7 +25,7 @@ var tags = {
 
 // Resource - App Service Plan
 //////////////////////////////////////////////////
-resource appServicePlan 'Microsoft.Web/serverfarms@2020-10-01' = {
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   name: appServicePlanName
   location: location
   tags: tags
@@ -29,9 +38,28 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-10-01' = {
   }
 }
 
+// Resource - App Service Plan - Diagnostic Settings
+//////////////////////////////////////////////////
+resource appServicePlanDiagnostics 'microsoft.insights/diagnosticSettings@2021-05-01-preview' = {
+  scope: appServicePlan
+  name: '${appServicePlan.name}-diagnostics'
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    storageAccountId: diagnosticsStorageAccountId
+    eventHubAuthorizationRuleId: eventHubNamespaceAuthorizationRuleId
+    logAnalyticsDestinationType: 'Dedicated'
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
 // Resource - App Service Plan - Autoscale Setting
 //////////////////////////////////////////////////
-resource autoscaleSetting 'Microsoft.insights/autoscalesettings@2015-04-01' = {
+resource autoscaleSetting 'Microsoft.Insights/autoscalesettings@2021-05-01-preview' = {
   name: '${appServicePlan.name}-autoscale'
   location: location
   tags: tags

--- a/src/bicep/azure_app_services/azure_app_services.bicep
+++ b/src/bicep/azure_app_services/azure_app_services.bicep
@@ -206,7 +206,10 @@ module appServicePlanModule 'azure_app_service_plan.bicep' = {
   ]
   params: {
     appServicePlanName: appServicePlanName
+    diagnosticsStorageAccountId: diagnosticsStorageAccount.id
+    eventHubNamespaceAuthorizationRuleId: eventHubNamespaceAuthorizationRule.id
     location:location
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
 }
 

--- a/src/bicep/azure_app_services/azure_app_services_adeapp.bicep
+++ b/src/bicep/azure_app_services/azure_app_services_adeapp.bicep
@@ -49,13 +49,15 @@ var tags = {
 
 // Resource - App Service - ADE App(s)
 //////////////////////////////////////////////////
-resource adeAppService 'Microsoft.Web/sites@2020-12-01' = [for (adeAppAppService, i) in adeAppAppServices: {
+resource adeAppService 'Microsoft.Web/sites@2022-03-01' = [for (adeAppAppService, i) in adeAppAppServices: {
   name: adeAppAppService.adeAppAppServiceName
   location: location
   tags: tags
   kind: 'container'
   properties: {
     serverFarmId: appServicePlanId
+    virtualNetworkSubnetId: vnetIntegrationSubnetId
+    vnetRouteAllEnabled: true
     httpsOnly: false
     siteConfig: {
       linuxFxVersion: 'DOCKER|${containerRegistryURL}/${adeAppAppService.containerImageName}'
@@ -92,25 +94,11 @@ resource adeAppService 'Microsoft.Web/sites@2020-12-01' = [for (adeAppAppService
           value: 'false'
         }
         {
-          name: 'WEBSITE_VNET_ROUTE_ALL'
-          value: '1'
-        }
-        {
           name: 'WEBSITE_DNS_SERVER'
           value: '168.63.129.16'
         }
       ]
     }
-  }
-}]
-
-// Resource - App Service - Networking - ADE App(s)
-//////////////////////////////////////////////////
-resource adeAppServiceNetworking 'Microsoft.Web/sites/config@2020-12-01' = [for (adeAppAppService, i) in adeAppAppServices: {
-  name: '${adeAppService[i].name}/virtualNetwork'
-  properties: {
-    subnetResourceId: vnetIntegrationSubnetId
-    swiftSupported: true
   }
 }]
 
@@ -164,7 +152,7 @@ resource adeAppServiceDiagnostics 'Microsoft.insights/diagnosticSettings@2021-05
 
 // Resource - Private Endpoint - App Service - ADE App(s)
 //////////////////////////////////////////////////
-resource adeAppServicePrivateEndpoint 'Microsoft.Network/privateEndpoints@2020-11-01' = [for (adeAppAppService, i) in adeAppAppServices: if (adeAppAppService.usePrivateEndpoint) {
+resource adeAppServicePrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-01-01' = [for (adeAppAppService, i) in adeAppAppServices: if (adeAppAppService.usePrivateEndpoint) {
   name: adeAppAppService.privateEndpointName
   location: location
   properties: {
@@ -187,7 +175,7 @@ resource adeAppServicePrivateEndpoint 'Microsoft.Network/privateEndpoints@2020-1
 
 // Resource - Private Endpoint Dns Group - Private Endpoint - App Service - ADE App(s)
 //////////////////////////////////////////////////
-resource adeAppServicePrivateEndpointDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = [for (adeAppAppService, i) in adeAppAppServices: if (adeAppAppService.usePrivateEndpoint) {
+resource adeAppServicePrivateEndpointDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-01-01' = [for (adeAppAppService, i) in adeAppAppServices: if (adeAppAppService.usePrivateEndpoint) {
   name: '${adeAppAppService.privateEndpointName}/dnsgroupname'
   dependsOn: [
     adeAppServicePrivateEndpoint

--- a/src/bicep/azure_app_services/azure_app_services_inspectorgadget.bicep
+++ b/src/bicep/azure_app_services/azure_app_services_inspectorgadget.bicep
@@ -47,15 +47,16 @@ var tags = {
 
 // Resource - App Service - Inspector Gadget
 //////////////////////////////////////////////////
-resource inspectorGadgetAppService 'Microsoft.Web/sites@2020-12-01' = {
+resource inspectorGadgetAppService 'Microsoft.Web/sites@2022-03-01' = {
   name: inspectorGadgetAppServiceName
   location: location
   tags: tags
   kind: 'container'
   properties: {
     serverFarmId: appServicePlanId
+    virtualNetworkSubnetId: vnetIntegrationSubnetId
+    vnetRouteAllEnabled: true
     httpsOnly: false
-
     siteConfig: {
       linuxFxVersion: inspectorGadgetDockerImage
       appSettings: [
@@ -64,25 +65,11 @@ resource inspectorGadgetAppService 'Microsoft.Web/sites@2020-12-01' = {
           value: 'Data Source=tcp:${inspectorGadgetSqlServerFQDN},1433;Initial Catalog=${inspectorGadgetSqlDatabaseName};User Id=${adminUserName}@${inspectorGadgetSqlServerFQDN};Password=${adminPassword};'
         }
         {
-          name: 'WEBSITE_VNET_ROUTE_ALL'
-          value: '1'
-        }
-        {
           name: 'WEBSITE_DNS_SERVER'
           value: '168.63.129.16'
         }
       ]
     }
-  }
-}
-
-// Resource - App Service - Networking - Inspector Gadget
-//////////////////////////////////////////////////
-resource inspectorGadgetAppServiceNetworking 'Microsoft.Web/sites/config@2020-12-01' = {
-  name: '${inspectorGadgetAppService.name}/virtualNetwork'
-  properties: {
-    subnetResourceId: vnetIntegrationSubnetId
-    swiftSupported: true
   }
 }
 


### PR DESCRIPTION
Fixes #187
Fixes #193

- Added Diagnostic Settings to App Service Plan
- Configured Route All: Enabled for App Services and removed legacy application settting