### PR TITLE
Removed AAD Graph-Related Operations

### DIFF
--- a/ade.ps1
+++ b/ade.ps1
@@ -142,7 +142,7 @@ try {
             $scriptsBaseUri = "https://raw.githubusercontent.com/azuredemoenvironment/ade/main/scripts"
         }
 
-        Deploy-AzureDemoEnvironment $armParameters $secureResourcePassword $secureCertificatePassword $wildcardCertificatePath
+        Deploy-AzureDemoEnvironment $armParameters
     }
 
     if ($deallocate) {

--- a/src/bicep/azure_governance/azure_governance.bicep
+++ b/src/bicep/azure_governance/azure_governance.bicep
@@ -10,6 +10,9 @@ param aliasRegion string
 @description('The selected Azure region for deployment.')
 param azureRegion string
 
+@description('The Base64 encoded certificate for Azure resources.')
+param certificateBase64String string
+
 @description('The list of allowed locations for resource deployment. Used in Azure Policy module.')
 param listOfAllowedLocations array
 
@@ -28,6 +31,9 @@ param listOfAllowedSKUs array = [
 
 @description('The location for all resources.')
 param location string = deployment().location
+
+@description('The password for Azure resources.')
+param resourcePassword string
 
 // Global Variables
 //////////////////////////////////////////////////
@@ -272,11 +278,13 @@ module keyVaultModule './azure_key_vault.bicep' = {
   ]
   params: {
     applicationGatewayManagedIdentityPrincipalID: identityModule.outputs.applicationGatewayManagedIdentityPrincipalId
+    certificateBase64String: certificateBase64String
     containerRegistryManagedIdentityPrincipalID: identityModule.outputs.containerRegistryManagedIdentityPrincipalId
     diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
     eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId
     keyVaultName: keyVaultName
     location: location
     logAnalyticsWorkspaceId: logAnalyticsModule.outputs.logAnalyticsWorkspaceId
+    resourcePassword: resourcePassword
   }
 }

--- a/src/bicep/azure_governance/azure_governance.bicep
+++ b/src/bicep/azure_governance/azure_governance.bicep
@@ -7,9 +7,6 @@ targetScope = 'subscription'
 @description('The user alias and Azure region defined from user input.')
 param aliasRegion string
 
-@description('The Azure Active Directory User ID.')
-param azureActiveDirectoryUserID string
-
 @description('The selected Azure region for deployment.')
 param azureRegion string
 
@@ -275,7 +272,6 @@ module keyVaultModule './azure_key_vault.bicep' = {
   ]
   params: {
     applicationGatewayManagedIdentityPrincipalID: identityModule.outputs.applicationGatewayManagedIdentityPrincipalId
-    azureActiveDirectoryUserID: azureActiveDirectoryUserID
     containerRegistryManagedIdentityPrincipalID: identityModule.outputs.containerRegistryManagedIdentityPrincipalId
     diagnosticsStorageAccountId: storageAccountDiagnosticsModule.outputs.diagnosticsStorageAccountId
     eventHubNamespaceAuthorizationRuleId: eventHubDiagnosticsModule.outputs.eventHubNamespaceAuthorizationRuleId

--- a/src/bicep/azure_governance/azure_governance.parameters.sample.json
+++ b/src/bicep/azure_governance/azure_governance.parameters.sample.json
@@ -1,19 +1,24 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": {        
+    "parameters": {
         "aliasRegion": {
             "value": "@@aliasRegion@@"
         },
         "azureRegion": {
             "value": "@@azureRegion@@"
         },
-        
+        "certificateBase64String": {
+            "value": "@@certificateBase64String@@"
+        },
         "listOfAllowedLocations": {
             "value": [
                 "@@azureRegion@@",
                 "@@azurePairedRegion@@"
             ]
+        },
+        "resourcePassword": {
+            "value": "@@resourcePassword@@"
         }
     }
 }

--- a/src/bicep/azure_governance/azure_governance.parameters.sample.json
+++ b/src/bicep/azure_governance/azure_governance.parameters.sample.json
@@ -5,9 +5,6 @@
         "aliasRegion": {
             "value": "@@aliasRegion@@"
         },
-        "azureActiveDirectoryUserID": {
-            "value": "@@azureActiveDirectoryUserID@@"
-        },
         "azureRegion": {
             "value": "@@azureRegion@@"
         },

--- a/src/bicep/azure_governance/azure_key_vault.bicep
+++ b/src/bicep/azure_governance/azure_key_vault.bicep
@@ -3,6 +3,9 @@
 @description('The Service Principal Name ID of the Application Gateway Managed Identity.')
 param applicationGatewayManagedIdentityPrincipalID string
 
+@description('The Base64 encoded certificate for Azure resources.')
+param certificateBase64String string
+
 @description('The Service Principal Name ID of the Container Registry Managed Identity.')
 param containerRegistryManagedIdentityPrincipalID string
 
@@ -20,6 +23,9 @@ param location string
 
 @description('The ID of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
+
+@description('The password for Azure resources.')
+param resourcePassword string
 
 // Variables
 //////////////////////////////////////////////////
@@ -88,6 +94,26 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' = {
         }
       }
     ]
+  }
+}
+
+// Resource - Key Vault - Secret - Certificate
+//////////////////////////////////////////////////
+resource certificateBase64StringSecret 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
+  parent: keyVault
+  name: 'certificate'
+  properties: {
+    value: certificateBase64String
+  }
+}
+
+// Resource - Key Vault - Secret - Certificate
+//////////////////////////////////////////////////
+resource resourcePasswordSecret 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
+  parent: keyVault
+  name: 'resourcePassword'
+  properties: {
+    value: resourcePassword
   }
 }
 

--- a/src/bicep/azure_governance/azure_key_vault.bicep
+++ b/src/bicep/azure_governance/azure_key_vault.bicep
@@ -81,18 +81,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' = {
           ]
         }
       }
-      {
-        objectId: 'abfa0a7c-a6b6-4736-8310-5855508787cd'
-        tenantId: subscription().tenantId
-        permissions: {
-          certificates: [
-            'get'
-          ]
-          secrets: [
-            'get'
-          ]
-        }
-      }
     ]
   }
 }
@@ -107,7 +95,7 @@ resource certificateBase64StringSecret 'Microsoft.KeyVault/vaults/secrets@2021-1
   }
 }
 
-// Resource - Key Vault - Secret - Certificate
+// Resource - Key Vault - Secret - Resource Password
 //////////////////////////////////////////////////
 resource resourcePasswordSecret 'Microsoft.KeyVault/vaults/secrets@2021-11-01-preview' = {
   parent: keyVault

--- a/src/bicep/azure_governance/azure_key_vault.bicep
+++ b/src/bicep/azure_governance/azure_key_vault.bicep
@@ -1,8 +1,5 @@
 // Parameters
 //////////////////////////////////////////////////
-@description('The Azure Active Directory User ID.')
-param azureActiveDirectoryUserID string
-
 @description('The Service Principal Name ID of the Application Gateway Managed Identity.')
 param applicationGatewayManagedIdentityPrincipalID string
 
@@ -52,24 +49,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' = {
     tenantId: subscription().tenantId
     publicNetworkAccess: 'enabled'
     accessPolicies: [
-      {
-        objectId: azureActiveDirectoryUserID
-        tenantId: subscription().tenantId
-        permissions: {
-          keys: [
-            'all'
-            'purge'
-          ]
-          secrets: [
-            'all'
-            'purge'
-          ]
-          certificates: [
-            'all'
-            'purge'
-          ]
-        }
-      }
       {
         objectId: applicationGatewayManagedIdentityPrincipalID
         tenantId: subscription().tenantId

--- a/src/ps/private/Certificates/Convert-WildcardCertificateToBase64String.ps1
+++ b/src/ps/private/Certificates/Convert-WildcardCertificateToBase64String.ps1
@@ -1,6 +1,5 @@
-function Deploy-WildcardCertificateToAzureKeyVault {
+function Convert-WildcardCertificateToBase64String {
     param(
-        [string] $keyVaultName,
         [SecureString] $secureCertificatePassword,
         [string] $wildcardCertificatePath
     )
@@ -13,18 +12,13 @@ function Deploy-WildcardCertificateToAzureKeyVault {
     # Convert Secure Password into Plain Text
     $certificatePasswordPlainText = ConvertFrom-SecureString -SecureString $secureCertificatePassword -AsPlainText
 
-    # Upload PFX Certificate to Key Vault as a Certificate
-    az keyvault certificate import --vault-name $keyVaultName --name 'pfx-certificate' --file $wildcardCertificatePath --password $certificatePasswordPlainText --only-show-errors
-    Confirm-LastExitCode
-
-    # TODO: move to separate function
+    # Convert to Base64 String
     $certificateFlags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
     $certificateCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
     $certificateCollection.Import($wildcardCertificatePath, $certificatePasswordPlainText, $certificateFlags)
     $pkcs12ContentType = [System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12
     $certificateBytes = $certificateCollection.Export($pkcs12ContentType)
     $encodedCertificate = [System.Convert]::ToBase64String($certificateBytes)
-    $secureEncodedCertificate = ConvertTo-SecureString $encodedCertificate -AsPlainText -Force
 
-    Set-AzureKeyVaultSecret $keyVaultName 'certificate' $secureEncodedCertificate 'application/x-pkcs12'
+    return $encodedCertificate
 }

--- a/src/ps/private/Governance/Deploy-AzureGovernance.ps1
+++ b/src/ps/private/Governance/Deploy-AzureGovernance.ps1
@@ -36,15 +36,6 @@ function Deploy-AzureGovernance {
     # Configure Azure KeyVault
     ##################################################
     Write-Status "Configuring Azure Key Vault $keyVaultName"
-
-    # Configure the resource password KeyVault secret.
-    Set-AzureKeyVaultSecret $keyVaultName 'resourcePassword' $secureResourcePassword
-
-    # Deploy the wildcard certificate KeyVault secret.
-    Deploy-WildcardCertificateToAzureKeyVault $keyVaultName $secureCertificatePassword $wildcardCertificatePath
-
-    # Create the Container Registry encryption key.
-    New-AzureKeyVaultKey $keyVaultName $keyVaultKeyName
     
     # Set the Azure KeyVault resource id for future deployments.
     Set-AzureKeyVaultResourceId $armParameters

--- a/src/ps/public/Actions/Deploy-AzureDemoEnvironment.ps1
+++ b/src/ps/public/Actions/Deploy-AzureDemoEnvironment.ps1
@@ -1,9 +1,6 @@
 function Deploy-AzureDemoEnvironment {
     param(
-        [object] $armParameters,
-        [SecureString] $secureResourcePassword,
-        [SecureString] $secureCertificatePassword,
-        [object] $wildcardCertificatePath
+        [object] $armParameters
     )
 
     Write-ScriptSection "Initializing Azure Demo Environment Deploy"
@@ -34,7 +31,7 @@ function Deploy-AzureDemoEnvironment {
     
     # Core Services
     ###################################
-    Deploy-AzureGovernance $armParameters $secureResourcePassword $secureCertificatePassword $wildcardCertificatePath
+    Deploy-AzureGovernance $armParameters
     Deploy-AzureNetworking $armParameters
     Deploy-AzureContainerRegistry $armParameters
     

--- a/src/ps/public/Parameters/Set-InitialArmParameters.ps1
+++ b/src/ps/public/Parameters/Set-InitialArmParameters.ps1
@@ -5,13 +5,13 @@ function Set-InitialArmParameters {
         [string] $resourceUserName,
         [string] $rootDomainName,
         [string] $localNetworkRange,
-        [string] $scriptsBaseUri,
         [SecureString] $secureResourcePassword,
         [SecureString] $secureCertificatePassword,
+        [string] $wildcardCertificatePath,
         [string] $azureRegion,
         [string] $azurePairedRegion,
         [string] $module,
-        [string] $wildcardCertificatePath,
+        [string] $scriptsBaseUri,
         [bool] $overwriteParameterFiles,
         [bool] $skipConfirmation
     )

--- a/src/ps/public/Parameters/Set-InitialArmParameters.ps1
+++ b/src/ps/public/Parameters/Set-InitialArmParameters.ps1
@@ -24,9 +24,6 @@ function Set-InitialArmParameters {
     $sourceAddressPrefix = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
     $acrName = "acr-ade-$aliasRegion-001".replace('-', '')
 
-    Write-Log 'Gathering User Information from az'
-    $adSignedInUser = az ad signed-in-user show | ConvertFrom-Json
-
     Write-Log 'Generating ARM Parameters'
 
     $armParameters = @{
@@ -46,10 +43,9 @@ function Set-InitialArmParameters {
 
         # Generated Parameters        
         'adminUserName'                            = $resourceUserName
-        'azureActiveDirectoryUserID'               = $adSignedInUser.objectId              
         'localNetworkGatewayAddressPrefix'         = $localNetworkRange
-        'logAnalyticsWorkspaceName'                = "log-ade-$aliasRegion-001"                  
-        'sourceAddressPrefix'                      = $sourceAddressPrefix        
+        'logAnalyticsWorkspaceName'                = "log-ade-$aliasRegion-001"
+        'sourceAddressPrefix'                      = $sourceAddressPrefix
         'sslCertificateName'                       = $rootDomainName
 
         # Required for Deploy-AzureAppServicePlanScaleDown.ps1

--- a/src/ps/public/Parameters/Set-InitialArmParameters.ps1
+++ b/src/ps/public/Parameters/Set-InitialArmParameters.ps1
@@ -5,10 +5,13 @@ function Set-InitialArmParameters {
         [string] $resourceUserName,
         [string] $rootDomainName,
         [string] $localNetworkRange,
+        [string] $scriptsBaseUri,
+        [SecureString] $secureResourcePassword,
+        [SecureString] $secureCertificatePassword,
         [string] $azureRegion,
         [string] $azurePairedRegion,
         [string] $module,
-        [string] $scriptsBaseUri,
+        [string] $wildcardCertificatePath,
         [bool] $overwriteParameterFiles,
         [bool] $skipConfirmation
     )
@@ -23,6 +26,9 @@ function Set-InitialArmParameters {
     $PairedRegionResourceGroupNamePrefix = "rg-ade-$aliasPairedRegion"
     $sourceAddressPrefix = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
     $acrName = "acr-ade-$aliasRegion-001".replace('-', '')
+
+    $certificateBase64String = Convert-WildcardCertificateToBase64String $secureCertificatePassword $wildcardCertificatePath
+    $plainTextResourcePassword = ConvertFrom-SecureString -SecureString $secureResourcePassword -AsPlainText
 
     Write-Log 'Generating ARM Parameters'
 
@@ -43,8 +49,10 @@ function Set-InitialArmParameters {
 
         # Generated Parameters        
         'adminUserName'                            = $resourceUserName
+        'certificateBase64String'                  = $certificateBase64String
         'localNetworkGatewayAddressPrefix'         = $localNetworkRange
         'logAnalyticsWorkspaceName'                = "log-ade-$aliasRegion-001"
+        'resourcePassword'                         = $plainTextResourcePassword
         'sourceAddressPrefix'                      = $sourceAddressPrefix
         'sslCertificateName'                       = $rootDomainName
 


### PR DESCRIPTION
AAD Graph is being deprecated and replaced by Microsoft Graph. `az` versions 2.37.0 and newer uses Microsoft Graph, which with certain Conditional Access policies will not run within the az Docker Image. The following updates were made to accommodate the change:

- Removed references to `az ad signed-in-user`
- Removed references to `$azureActiveDirectoryUserId`
- Moved Key Vault secret assignment into ARM instead of being done via PowerShell, which required proper Condition Access adherence
- Cleaned up old secrets/certificates in Key Vault that were originally going to be used for App Services

TODO: add a section in the README on how to allow access to Key Vault secrets by creating an Access Policy (post-deployment).

For more information on the Microsoft Graph change within az, see: https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration

Fixes #198
